### PR TITLE
fix: add missing tenacity dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2622,7 +2622,7 @@ version = "8.5.0"
 description = "Retry code until it succeeds"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687"},
     {file = "tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78"},
@@ -3020,4 +3020,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8"
-content-hash = "6571b25209913b96ce2d930a7013290041eb092d9427ffdc9491680477f68b91"
+content-hash = "d22300b770809af1668ee9c6e30aaf779d02b99f84e21c307a65c64246735cc5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ packages = [{include = "keystone_keycloak_backend"}]
 [tool.poetry.dependencies]
 python = "^3.8"
 python-keycloak = "^3.6.1"
+tenacity = ">=6.3.1,<9.2.0"
 
 [tool.poetry.group.dev.dependencies]
 keystone = ">=22.0.0"
 pytest = "^7.4.0"
 pytest-cov = "^4.1.0"
-tenacity = "^8.0.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Add missing tenacity dependency:
```
keystone-api [Tue Dec 09 09:49:55.102765 2025] [wsgi:error] [pid 12:tid 140099856242368] [remote 10.244.1.71:53782]     from tenacity import Retrying, retry_if_exception_type, stop_after_attempt                                                                                                                       
keystone-api [Tue Dec 09 09:49:55.102811 2025] [wsgi:error] [pid 12:tid 140099856242368] [remote 10.244.1.71:53782] ModuleNotFoundError: No module named 'tenacity'
```